### PR TITLE
Fix edit command accepting empty tag input

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -100,8 +100,6 @@ public class EditCommandParser implements Parser<EditCommand> {
 
     /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;
@@ -110,8 +108,11 @@ public class EditCommandParser implements Parser<EditCommand> {
             return Optional.empty();
         }
 
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+        if (tags.size() == 1 && tags.contains("")) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        }
+
+        return Optional.of(ParserUtil.parseTags(tags));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -14,7 +14,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 


### PR DESCRIPTION
Fixes #253

### Summary
This PR fixes a bug where `edit INDEX ta/` is accepted even though no valid tag value is provided and no actual edit is made.

### What was happening
Previously, an empty tag input like `ta/` was converted into an empty set during parsing. As a result, the edit command was accepted and reported success, even though the athlete's tags remained unchanged.

### Fix
Updated `EditCommandParser#parseTagsForEdit(...)` to reject empty tag input instead of treating it as a valid empty set.

### Before
- `edit 1 ta/` was accepted
- command reported success
- no actual change was made

### After
- `edit 1 ta/` is rejected during parsing

### Why this fix
This prevents misleading command behaviour and ensures the system does not report a successful edit when nothing was actually modified.

### Testing
- Ran relevant tests after updating the parser
- Verified that empty tag input is no longer accepted