### PR TITLE
Fix invalid emergency contact in Developer Guide sample addressbook.json

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -532,7 +532,7 @@ Sample `addressbook.json`:
       "phone": "93579135",
       "email": "lucas.wong@example.com",
       "address": "27 Serangoon North Ave 4",
-      "emergencyContact": "N/A",
+      "emergencyContact": "Father 91234567",
       "startDate": "30/01/2024",
       "tags": ["teamC"],
       "availableDays": [],


### PR DESCRIPTION
Closes #298

This PR fixes an invalid `emergencyContact` value in the Developer Guide sample `addressbook.json`.

Previously, the sample used `"emergencyContact": "N/A"`, which does not conform to the required `Relationship Phone` format and may cause confusion or data loading issues during testing.

This update replaces the invalid value with a valid example that follows the expected format.

This ensures that the sample data in the Developer Guide is accurate and usable for manual testing.