### PR TITLE
Fix edit command resetting filtered list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMERGENCY_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -98,7 +97,6 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(formatAthleteMessage(editedPerson));
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -128,12 +128,13 @@ public class EditCommandTest {
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-            new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = EditCommand.formatAthleteMessage(editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        expectedModel.setPerson(expectedModel.getFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Closes #280

## Summary
Fixes an issue where the `edit` command resets the filtered list back to the full list after execution.

## Problem
When a user performs `find` followed by `edit`, the application currently clears the filtered view and displays the full list. This disrupts workflows where users want to continue editing within a subset of athletes, and may lead to index inconsistencies.

## Solution
Removed the forced reset of the filtered list in `EditCommand`. The command now preserves the current filtered view after a successful edit.

## Changes
- Removed `model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS)` from `EditCommand`
- Updated `EditCommandTest` to reflect the preserved filtered list behavior

## Result
- Filtered lists are preserved after editing
- User workflow is more consistent when working within subsets
- Indices remain stable within the filtered context